### PR TITLE
Add -DWITH_PYTHON=ON to setup.py for compatibility

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,6 +43,7 @@ class CMakeBuild(build_ext):
         
         cmake_args = ['-DCMAKE_LIBRARY_OUTPUT_DIRECTORY=' + extdir,
                       '-DCMAKE_SWIG_OUTDIR=' + extdir,
+                      '-DWITH_PYTHON=ON',
                       '-DPython3_EXECUTABLE:FILEPATH=' + sys.executable,
 
                       # TODO: Still need this?


### PR DESCRIPTION
To make setup.py compatible with google/s2-geometry as of 2021-05-07
That is, commit efb124d8eaf3433323d3e877dedd5e94a63339a3 which only builds the python bindings if WITH_PYTHON=ON.